### PR TITLE
Fix Vercel build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ If you'd rather see all of the lod gs in one place, delete the
 In order to both deploy the frontend and Convex, run this as the build command from the apps/web directory:
 
 ```sh
-cd ../../packages/backend && npx convex deploy --cmd 'cd ../../apps/app && turbo run build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL
+cd ../../packages/backend && npx convex deploy --cmd 'cd ../../apps/web && turbo run build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL
 ```
 
-There is a vercel.json file in the apps/web directory with this configuration for Vercel.
+When deploying on Vercel, set the project root to `apps/web` and use the build command above.
 
 ## What's inside?
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ cd ../../packages/backend && npx convex deploy --cmd 'cd ../../apps/web && turbo
 ```
 
 When deploying on Vercel, set the project root to `apps/web` and use the build command above.
+Vercel only exposes environment variables listed in `turbo.json` to your tasks, so
+be sure to include `NEXT_PUBLIC_CONVEX_URL`, `CONVEX_DEPLOY_KEY`, and
+`CLERK_SECRET_KEY` in the `env` array of your build task.
 
 ## What's inside?
 

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,12 @@
   "tasks": {
     "build": {
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "env": [
+        "NEXT_PUBLIC_CONVEX_URL",
+        "CONVEX_DEPLOY_KEY",
+        "CLERK_SECRET_KEY"
+      ]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
- fix build command path for Vercel
- note project root for Vercel deployment

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856d77566d8832a8ea3417b9dcaaad7