### PR TITLE
Add initial permissions system

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type {
 import type * as notes from "../notes.js";
 import type * as openai from "../openai.js";
 import type * as utils from "../utils.js";
+import type * as permissions from "../permissions.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -29,6 +30,7 @@ declare const fullApi: ApiFromModules<{
   notes: typeof notes;
   openai: typeof openai;
   utils: typeof utils;
+  permissions: typeof permissions;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/packages/backend/convex/permissions.ts
+++ b/packages/backend/convex/permissions.ts
@@ -1,0 +1,60 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { Auth } from "convex/server";
+
+export const getUserId = async (ctx: { auth: Auth }) => {
+  return (await ctx.auth.getUserIdentity())?.subject;
+};
+
+export const can = async (
+  ctx: { db: any; auth: Auth },
+  permission: string,
+): Promise<boolean> => {
+  const userId = await getUserId(ctx);
+  if (!userId) return false;
+  const existing = await ctx.db
+    .query("userPermissions")
+    .withIndex("by_user_permission", (q: any) =>
+      q.eq("userId", userId).eq("permission", permission),
+    )
+    .unique();
+  return !!existing;
+};
+
+export const grantPermission = mutation({
+  args: {
+    userId: v.string(),
+    permission: v.string(),
+  },
+  handler: async (ctx, { userId, permission }) => {
+    await ctx.db.insert("userPermissions", { userId, permission });
+  },
+});
+
+export const revokePermission = mutation({
+  args: {
+    userId: v.string(),
+    permission: v.string(),
+  },
+  handler: async (ctx, { userId, permission }) => {
+    const existing = await ctx.db
+      .query("userPermissions")
+      .withIndex("by_user_permission", (q: any) =>
+        q.eq("userId", userId).eq("permission", permission),
+      )
+      .unique();
+    if (existing?._id) {
+      await ctx.db.delete(existing._id);
+    }
+  },
+});
+
+export const listPermissions = query({
+  args: { userId: v.string() },
+  handler: async (ctx, { userId }) => {
+    return await ctx.db
+      .query("userPermissions")
+      .withIndex("by_user", (q: any) => q.eq("userId", userId))
+      .collect();
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -8,4 +8,10 @@ export default defineSchema({
     content: v.string(),
     summary: v.optional(v.string()),
   }),
+  userPermissions: defineTable({
+    userId: v.string(),
+    permission: v.string(),
+  })
+    .index("by_user_permission", ["userId", "permission"])
+    .index("by_user", ["userId"]),
 });


### PR DESCRIPTION
## Summary
- define `userPermissions` table in Convex schema
- create `permissions` controller with helper and CRUD functions
- include permissions module in generated API types

## Testing
- `yarn format`
- `npx tsc -p packages/backend/convex/tsconfig.json --noEmit` *(fails: Cannot find module 'convex/values')*

------
https://chatgpt.com/codex/tasks/task_e_6856f1d73c4c832a89f6fbd95f0d22f0