### PR TITLE
Add patient dashboard and doctor analysis

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,11 @@
+import Header from "@/components/Header";
+import Dashboard from "@/components/patient/Dashboard";
+
+export default function Page() {
+  return (
+    <main className="bg-[#F5F7FE] h-screen">
+      <Header />
+      <Dashboard />
+    </main>
+  );
+}

--- a/apps/web/src/components/patient/CreateAnalysis.tsx
+++ b/apps/web/src/components/patient/CreateAnalysis.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@packages/backend/convex/_generated/api";
+import { useMutation } from "convex/react";
+
+interface Props {
+  patientId: string;
+}
+
+export default function CreateAnalysis({ patientId }: Props) {
+  const [content, setContent] = useState("");
+  const create = useMutation(api.analysis.createAnalysis);
+
+  const submit = async () => {
+    await create({ patientId, content });
+    setContent("");
+  };
+
+  return (
+    <div className="my-4 space-y-2">
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Write analysis"
+        className="w-full border p-2"
+      />
+      <button onClick={submit} className="button px-4 py-2 text-white">
+        Submit Analysis
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/patient/Dashboard.tsx
+++ b/apps/web/src/components/patient/Dashboard.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { api } from "@packages/backend/convex/_generated/api";
+import { useQuery } from "convex/react";
+import CreateAnalysis from "./CreateAnalysis";
+import { useUser } from "@clerk/nextjs";
+
+export default function Dashboard() {
+  const { user } = useUser();
+  const patientId = user?.id ?? "";
+
+  const tests = useQuery(api.tests.getRecentTests);
+  const analyses = useQuery(api.analysis.getPatientAnalysis, { patientId });
+
+  return (
+    <div className="container p-4 space-y-6">
+      <h2 className="text-2xl font-semibold">Recent Tests</h2>
+      <ul className="space-y-2">
+        {tests?.map((t) => (
+          <li key={t._id} className="border p-2">
+            <strong>{t.testName}</strong>: {t.result}
+          </li>
+        ))}
+      </ul>
+
+      <h2 className="text-2xl font-semibold mt-4">Doctor Analysis</h2>
+      <ul className="space-y-2">
+        {analyses?.map((a) => (
+          <li key={a._id} className="border p-2">
+            {a.content}
+          </li>
+        ))}
+      </ul>
+
+      {/* Allow doctors to submit analysis */}
+      {user && <CreateAnalysis patientId={patientId} />}
+    </div>
+  );
+}

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -13,10 +13,12 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as analysis from "../analysis.js";
 import type * as notes from "../notes.js";
 import type * as openai from "../openai.js";
-import type * as utils from "../utils.js";
 import type * as permissions from "../permissions.js";
+import type * as tests from "../tests.js";
+import type * as utils from "../utils.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -27,10 +29,12 @@ import type * as permissions from "../permissions.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  analysis: typeof analysis;
   notes: typeof notes;
   openai: typeof openai;
-  utils: typeof utils;
   permissions: typeof permissions;
+  tests: typeof tests;
+  utils: typeof utils;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/packages/backend/convex/analysis.ts
+++ b/packages/backend/convex/analysis.ts
@@ -1,0 +1,54 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { getUserId } from "./notes";
+import { can } from "./permissions";
+
+const isDoctorOfPatient = async (
+  ctx: any,
+  doctorId: string,
+  patientId: string,
+) => {
+  const existing = await ctx.db
+    .query("doctorPatients")
+    .withIndex("by_patient_doctor", (q: any) =>
+      q.eq("patientId", patientId).eq("doctorId", doctorId),
+    )
+    .unique();
+  return !!existing;
+};
+
+export const addDoctorForPatient = mutation({
+  args: { patientId: v.string(), doctorId: v.string() },
+  handler: async (ctx, { patientId, doctorId }) => {
+    const userId = await getUserId(ctx);
+    if (userId !== patientId) throw new Error("Unauthorized");
+    await ctx.db.insert("doctorPatients", { patientId, doctorId });
+  },
+});
+
+export const createAnalysis = mutation({
+  args: { patientId: v.string(), content: v.string() },
+  handler: async (ctx, { patientId, content }) => {
+    const doctorId = await getUserId(ctx);
+    if (!doctorId) throw new Error("User not authenticated");
+    if (!(await can(ctx, "doctor"))) throw new Error("Not authorized");
+    if (!(await isDoctorOfPatient(ctx, doctorId, patientId))) {
+      throw new Error("Doctor not associated with patient");
+    }
+    return await ctx.db.insert("analysis", { patientId, doctorId, content });
+  },
+});
+
+export const getPatientAnalysis = query({
+  args: { patientId: v.optional(v.string()) },
+  handler: async (ctx, { patientId }) => {
+    const userId = patientId ?? (await getUserId(ctx));
+    if (!userId) return null;
+    const analyses = await ctx.db
+      .query("analysis")
+      .withIndex("by_patient", (q: any) => q.eq("patientId", userId))
+      .collect();
+    analyses.sort((a: any, b: any) => b._creationTime - a._creationTime);
+    return analyses;
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -14,4 +14,21 @@ export default defineSchema({
   })
     .index("by_user_permission", ["userId", "permission"])
     .index("by_user", ["userId"]),
+  tests: defineTable({
+    patientId: v.string(),
+    testName: v.string(),
+    result: v.string(),
+  }).index("by_patient", ["patientId"]),
+  analysis: defineTable({
+    patientId: v.string(),
+    doctorId: v.string(),
+    content: v.string(),
+  }).index("by_patient", ["patientId"]),
+  doctorPatients: defineTable({
+    patientId: v.string(),
+    doctorId: v.string(),
+  })
+    .index("by_patient_doctor", ["patientId", "doctorId"])
+    .index("by_doctor", ["doctorId"])
+    .index("by_patient", ["patientId"]),
 });

--- a/packages/backend/convex/tests.ts
+++ b/packages/backend/convex/tests.ts
@@ -1,0 +1,29 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { getUserId } from "./notes";
+
+export const getRecentTests = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return null;
+    const tests = await ctx.db
+      .query("tests")
+      .withIndex("by_patient", (q: any) => q.eq("patientId", userId))
+      .collect();
+    tests.sort((a: any, b: any) => b._creationTime - a._creationTime);
+    return tests;
+  },
+});
+
+export const addTest = mutation({
+  args: {
+    testName: v.string(),
+    result: v.string(),
+  },
+  handler: async (ctx, { testName, result }) => {
+    const patientId = await getUserId(ctx);
+    if (!patientId) throw new Error("User not found");
+    return await ctx.db.insert("tests", { patientId, testName, result });
+  },
+});

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,7 +12,7 @@
     "convex": "^1.13.0",
     "openai": "^4.45.0"
   },
-   "devDependencies": {
+  "devDependencies": {
     "typescript": "^5.7.3"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -6,11 +6,7 @@
     "build": {
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
       "dependsOn": ["^build"],
-      "env": [
-        "NEXT_PUBLIC_CONVEX_URL",
-        "CONVEX_DEPLOY_KEY",
-        "CLERK_SECRET_KEY"
-      ]
+      "env": ["NEXT_PUBLIC_CONVEX_URL", "CONVEX_DEPLOY_KEY", "CLERK_SECRET_KEY"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
- add doctor and patient tables to `schema`
- add Convex functions for tests and doctor analysis
- create patient dashboard page with analysis form
- run code formatting

## Testing
- `npx -y convex codegen`
- `yarn format`


------
https://chatgpt.com/codex/tasks/task_e_68699fb92dc4832ab8c084e2d5dc224b